### PR TITLE
Location is no longer stored if it is invalid

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,12 +35,13 @@ class App extends Component {
   }
 
   getWeather = (location) => {
-    this.saveLocation(location)
+    
     const city = location.split(', ')[0]
     const stateCode = location.split(', ')[1]
     const root = `http://api.wunderground.com/api/${apiKey}//`;
     const url = `${root}conditions/geolookup/hourly/forecast10day/q/${stateCode}/${city}.json`;
     fetch(url).then(data => data.json()).then(parsedData => {
+        this.saveLocation(location) 
         this.setState({
           now: getCurrentWeather(parsedData),
           sevenHour: getHourlyForecast(parsedData),
@@ -48,6 +49,7 @@ class App extends Component {
           invalidLocation: false
       })
     }).catch(err => {
+      localStorage.clear();
       this.setState({
         invalidLocation: true
       })

--- a/src/tests/App.test.js
+++ b/src/tests/App.test.js
@@ -51,6 +51,8 @@ configure({ adapter: new Adapter() });
     app.getWeather = jest.fn();
     const appState = app.state()
     const localStorage = {'location': 'Denver, CO'}
+    app.instance().getWeather('denver, co')
+    app.instance().saveLocation('denver, co')
 
     expect(app.instance().checkLocalStorage()).toEqual('denver, co')
   })


### PR DESCRIPTION
Previously the app would save a users location to re-render the page for them on a refresh, regardless of tha validity of the location. Now the location is only saved when the location is valid. Updated a test to represent that change, because it is now running in the fetch call and catch, which doesn't translate to testing